### PR TITLE
Drop pageSize to 20 per change in Netflix API

### DIFF
--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -117,7 +117,7 @@ const downloadHistory = async (event) => {
 
   /* We set the records amount to infinity for now. Once the API sends back
      less than pageSize results, we stop crawling. */
-  const pageSize = 100
+  const pageSize = 20
   const pagesToLoad = Infinity
 
   /* Download each page and append the results in to one array.


### PR DESCRIPTION
as noticed in #3 on 6/20/18 Netflix will only return 20 results per page, regardless of asking for more.